### PR TITLE
Use `pak::pak` in README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -44,7 +44,7 @@ Or install the development version of r2dii.data with something like this:
 
 ```r
 # install.packages("devtools")
-devtools::install_github("RMI-PACTA/r2dii.data")
+pak::pak("RMI-PACTA/r2dii.data")
 ```
 
 ## Example


### PR DESCRIPTION
This is now the recommended approach for installing GitHub packages