### PR TITLE
Add a workflow to automatically add issues and PRs to my maintenance GH project

### DIFF
--- a/.github/workflows/add-prs-and-issues-to-project.yml
+++ b/.github/workflows/add-prs-and-issues-to-project.yml
@@ -1,0 +1,21 @@
+name: Add new issues and PRs to @jdhoffa's Maintenance Responsibilities GH Project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/RMI-PACTA/projects/12
+          github-token: ${{ secrets.PAT_ADD_ISSUES_TO_PROJECT }}


### PR DESCRIPTION
I have created a GitHub project board here to track all issues and PRs across all of the repositories I maintain:
https://github.com/orgs/RMI-PACTA/projects/12

This PR adds a workflow that automatically adds issues and PRs to that project. 

Adapted from @cjyetman's action. 

FYI @RMI-PACTA/developers in case you find this useful or interesting. Ping me if you would like an explanation of this. 