### PR TITLE
Modernize and knit README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -43,8 +43,8 @@ install.packages("r2dii.data")
 Or install the development version of r2dii.data with something like this:
 
 ```r
-# install.packages("devtools")
-devtools::install_github("RMI-PACTA/r2dii.data")
+# install.packages("pak")
+pak::pak("RMI-PACTA/r2dii.data")
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Or install the development version of r2dii.data with something like
 this:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("RMI-PACTA/r2dii.data")
+# install.packages("pak")
+pak::pak("RMI-PACTA/r2dii.data")
 ```
 
 ## Example


### PR DESCRIPTION
`tidyverse` now recommends using `pak` instead of `devtools::install_github`