### PR TITLE
Bump roxygen version and re-document

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,4 +44,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/man/iso_codes.Rd
+++ b/man/iso_codes.Rd
@@ -30,8 +30,8 @@ head(iso_codes)
 \link{data_dictionary}
 
 Other iso codes: 
-\code{\link{region_isos_demo}},
-\code{\link{region_isos}}
+\code{\link{region_isos}},
+\code{\link{region_isos_demo}}
 }
 \concept{iso codes}
 \keyword{datasets}


### PR DESCRIPTION
Updated documentation is purely cosmetic. I guess a result of some change in `roxygen`