### PR TITLE
upkeep: update deprecation message

### DIFF
--- a/data/cnb_classification.R
+++ b/data/cnb_classification.R
@@ -2,7 +2,7 @@ delayedAssign("cnb_classification", {
   on_r_cmd <- !identical(Sys.getenv("R_CMD"), "")
   if (!on_r_cmd) {
     warning(
-      "The dataset `cnb_classification` will be superseded as of r2dii.data 0.5.0 (expected Q2 2024).",
+      "The dataset `cnb_classification` will be superseded as of r2dii.data 0.6.0 (expected Q3 2024).",
       "\nPlease see `sector_classifications` for available datasets",
       call. = FALSE
     )


### PR DESCRIPTION
I messed up writing this message in the first place. 
The deprecation of `cnb_classification` will BEGIN as of `r2dii.data v0.5.0`, but deprecation won't be completed until the following release (`v0.6.0`) 

Relates to #329 