### PR TITLE
add missing `>` from #414

### DIFF
--- a/R/co2_intensity_scenario_demo.R
+++ b/R/co2_intensity_scenario_demo.R
@@ -1,8 +1,8 @@
-#' A prepared \ifelse{html}{\out{CO<sub>2</sub}}{\eqn{CO_2}{CO~2~}} intensity
+#' A prepared \ifelse{html}{\out{CO<sub>2</sub>}}{\eqn{CO_2}{CO~2~}} intensity
 #' climate scenario dataset for demonstration
 #'
 #' @description
-#' Fake \ifelse{html}{\out{CO<sub>2</sub}}{\eqn{CO_2}{CO~2~}} intensity climate
+#' Fake \ifelse{html}{\out{CO<sub>2</sub>}}{\eqn{CO_2}{CO~2~}} intensity climate
 #' scenario dataset, prepared for the software PACTA (Paris Agreement Capital
 #' Transition Assessment). It imitates climate scenario data (e.g. from the
 #' International Energy Agency (IEA)) including the change through time in

--- a/man/co2_intensity_scenario_demo.Rd
+++ b/man/co2_intensity_scenario_demo.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{co2_intensity_scenario_demo}
 \alias{co2_intensity_scenario_demo}
-\title{A prepared \ifelse{html}{\out{CO<sub>2</sub}}{\eqn{CO_2}{CO~2~}} intensity
+\title{A prepared \ifelse{html}{\out{CO<sub>2</sub>}}{\eqn{CO_2}{CO~2~}} intensity
 climate scenario dataset for demonstration}
 \format{
 An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 22 rows and 7 columns.
@@ -12,7 +12,7 @@ An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) w
 co2_intensity_scenario_demo
 }
 \description{
-Fake \ifelse{html}{\out{CO<sub>2</sub}}{\eqn{CO_2}{CO~2~}} intensity climate
+Fake \ifelse{html}{\out{CO<sub>2</sub>}}{\eqn{CO_2}{CO~2~}} intensity climate
 scenario dataset, prepared for the software PACTA (Paris Agreement Capital
 Transition Assessment). It imitates climate scenario data (e.g. from the
 International Energy Agency (IEA)) including the change through time in


### PR DESCRIPTION
#414 introduced a minor bug in the documentation because it was missing a `>`, which caused problems with the HTML rendering of one of the doc pages:

https://rmi-pacta.github.io/r2dii.data/dev/reference/co2_intensity_scenario_demo.html